### PR TITLE
Add readonly property url, json to BOJProblem

### DIFF
--- a/boj/problem.py
+++ b/boj/problem.py
@@ -30,9 +30,9 @@ class BOJProblem(BaseProblem):
     LANGUAGE_ENGLISH = 1
 
     def __init__(self, number: int, language: int = 0) -> None:
-        # Use problem url as id
-        self._url = f'https://www.acmicpc.net/problem/{number:d}'
-        super().__init__(id=self._url)
+        super().__init__(
+            id=f"https://www.acmicpc.net/problem/{number:d}"
+        )
         self._language: int = language
         self._data: List[Dict[str, str]]
         self._json: str
@@ -58,6 +58,10 @@ class BOJProblem(BaseProblem):
         # Update instance vars
         self._json = base64.b64decode(text_base64)
         self._data = json.loads(self._json)
+
+    @property
+    def url(self) -> str:
+        return self.id
 
     @property
     def data(self) -> List[Dict[str, str]]:

--- a/boj/problem.py
+++ b/boj/problem.py
@@ -35,6 +35,7 @@ class BOJProblem(BaseProblem):
         super().__init__(id=self._url)
         self._language: int = language
         self._data: List[Dict[str, str]]
+        self._json: str
         self._set_data()
         # Use Korean as default language
         if self._language >= len(self._data):
@@ -54,13 +55,17 @@ class BOJProblem(BaseProblem):
         soup = BeautifulSoup(text_html, 'html.parser')
         soup_tag: Tag = soup.select_one('#problem-lang-base64')  # type: ingore
         text_base64 = soup_tag.text
-        text_json = base64.b64decode(text_base64)
-        data_dict = json.loads(text_json)
-        self._data = data_dict
+        # Update instance vars
+        self._json = base64.b64decode(text_base64)
+        self._data = json.loads(self._json)
 
     @property
     def data(self) -> List[Dict[str, str]]:
         return self._data
+
+    @property
+    def json(self) -> str:
+        return self._json
 
     @property
     def problem_id(self) -> int:

--- a/boj/problem.py
+++ b/boj/problem.py
@@ -32,7 +32,7 @@ class BOJProblem(BaseProblem):
     LANGUAGE_ENGLISH = 1
 
     def __init__(self, number: int, language: Optional[int] = None) -> None:
-        self._json: str
+        self._json: bytes
         self._data: List[Dict[str, str]]
         super().__init__(
             id=f"https://www.acmicpc.net/problem/{number:d}"
@@ -48,7 +48,7 @@ class BOJProblem(BaseProblem):
         return self._data
 
     @property
-    def json(self) -> str:
+    def json(self) -> bytes:
         return self._json
 
     @property
@@ -107,8 +107,8 @@ class BOJProblem(BaseProblem):
             if soup_tag is None:
                 raise Exception
             text_base64 = soup_tag.text
-            text_json = base64.b64decode(text_base64)
-            dict_data = json.loads(text_json)
+            text_json: bytes = base64.b64decode(text_base64)
+            dict_data: List[Dict[str, str]] = json.loads(text_json)
             if not dict_data:
                 raise Exception
         except InvalidSchema:

--- a/boj/problem.py
+++ b/boj/problem.py
@@ -1,10 +1,12 @@
 import base64
 import json
-from typing import Dict, List
+from textwrap import dedent
+from typing import Dict, List, Optional
 
 from bs4 import BeautifulSoup
 from bs4.element import Tag
 from requests import request
+from requests.sessions import InvalidSchema
 
 
 class BaseProblem:
@@ -29,35 +31,13 @@ class BOJProblem(BaseProblem):
     LANGUAGE_KOREAN = 0
     LANGUAGE_ENGLISH = 1
 
-    def __init__(self, number: int, language: int = 0) -> None:
+    def __init__(self, number: int, language: Optional[int] = None) -> None:
+        self._json: str
+        self._data: List[Dict[str, str]]
         super().__init__(
             id=f"https://www.acmicpc.net/problem/{number:d}"
         )
-        self._language: int = language
-        self._data: List[Dict[str, str]]
-        self._json: str
-        self._set_data()
-        # Use Korean as default language
-        if self._language >= len(self._data):
-            self._language = self.LANGUAGE_KOREAN
-        # Make document aliases
-        for key, value in self._data[self._language].items():
-            self._document[key] = value
-
-    def _set_data(self) -> List[Dict[str, str]]:
-        """백준 온라인 저지로 부터 문제 데이터를 읽어옵니다.
-
-        문제 페이지에서 base64 인코딩 형태로 저장된 json 데이터를 사용합니다.
-        데이터는 리스트로 이루어져 있으며, 각 원소는 언어별 문제 데이터를 담고 있습니다.
-        """
-        response = request('GET', self._url)
-        text_html = response.text
-        soup = BeautifulSoup(text_html, 'html.parser')
-        soup_tag: Tag = soup.select_one('#problem-lang-base64')  # type: ingore
-        text_base64 = soup_tag.text
-        # Update instance vars
-        self._json = base64.b64decode(text_base64)
-        self._data = json.loads(self._json)
+        self._load_data(language)
 
     @property
     def url(self) -> str:
@@ -110,3 +90,49 @@ class BOJProblem(BaseProblem):
     @property
     def problem_lang_tcode(self) -> str:
         return self._document['problem_lang_tcode']
+
+    def _load_data(self, language: Optional[int] = None) -> None:
+        """백준 온라인 저지로 부터 문제 데이터를 읽어옵니다.
+
+        문제 페이지에서 base64 인코딩 형태로 저장된 json 데이터를 사용합니다.
+        데이터는 리스트로 이루어져 있으며, 각 원소는 언어별 문제 데이터를 담고 있습니다.
+        """
+        if language is None:
+            language = self.LANGUAGE_KOREAN
+        try:
+            response = request('GET', self.url)
+            soup = BeautifulSoup(response.text, 'html.parser')
+            soup_tag: Tag = soup.select_one(
+                '#problem-lang-base64')  # type: ingore
+            if soup_tag is None:
+                raise Exception
+            text_base64 = soup_tag.text
+            text_json = base64.b64decode(text_base64)
+            dict_data = json.loads(text_json)
+            if not dict_data:
+                raise Exception
+        except InvalidSchema:
+            raise InvalidSchema(dedent('''
+                URL 스키마가 올바르지 않습니다.
+                올바른 프로토콜(http, https)을 사용중인지 확인하세요.
+            '''))
+        except ConnectionError:
+            raise ConnectionError(dedent('''
+                URL로 부터 데이터를 읽어올 수 없습니다.
+                {url}
+            '''.format(url=self._url)))
+        except Exception as exception:
+            raise Exception(dedent('''
+                    문제 데이터를 읽어올 수 없습니다.
+                    백준 온라인 저지의 사이트 구조가 변경되었거나,
+                    주소가 이전 되었을 수도 있습니다.
+                '''),
+                exception
+            )
+        finally:
+            self._json = text_json
+            self._data = dict_data
+            self._language = language
+            self._document.clear()
+            for key, value in dict_data[language].items():
+                self._document[key] = value


### PR DESCRIPTION
## 개요

`BOJProblem` 인터페이스에 `json`, `url` 프로퍼티를 추가하였습니다.

- `json`: 백준 문제 페이지의 base64 데이터를 해석하면 나오는 json 데이터입니다. data를 파싱하기 위해 사용하는 근간이 되는 데이터입니다. (이 데이터를 가져오는 방법은 #50 에서 간단히 소개되어있습니다.)
- `url`: 백준 문제 페이지의 url 주소입니다. 이 주소로부터 문제 data를 가져오게 됩니다.
