### PR TITLE
Fix Dockerfile cannot use requirements.txt

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -10,9 +10,9 @@ ARG NODE_VERSION="lts/*"
 RUN if [ "${INSTALL_NODE}" = "true" ]; then su vscode -c "umask 0002 && . /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION} 2>&1"; fi
 
 # [Optional] If your pip requirements rarely change, uncomment this section to add them to the image.
-# COPY requirements.txt /tmp/pip-tmp/
-# RUN pip3 --disable-pip-version-check --no-cache-dir install -r /tmp/pip-tmp/requirements.txt \
-#    && rm -rf /tmp/pip-tmp
+COPY requirements.txt /tmp/pip-tmp/
+RUN pip3 --disable-pip-version-check --no-cache-dir install -r /tmp/pip-tmp/requirements.txt \
+    && rm -rf /tmp/pip-tmp
 
 # [Optional] Uncomment this section to install additional OS packages.
 # RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -20,5 +20,3 @@ RUN if [ "${INSTALL_NODE}" = "true" ]; then su vscode -c "umask 0002 && . /usr/l
 
 # [Optional] Uncomment this line to install global node packages.
 # RUN su vscode -c "source /usr/local/share/nvm/nvm.sh && npm install -g <your-package-here>" 2>&1
-
-RUN pip3 install -r requirements.txt


### PR DESCRIPTION
## 개요

문제가 되던 라인을 삭제하였고,

VS Code를 이용하여 생성한 Dockerfile의 주석처리된 부분 중, requirements.txt를 간단히 세팅할 수 있는 부분을 발견하여, 해당영역의 주석을 해제하였습니다.

Rebuild 및 Reopen in Container 옵션을 재실행 하였습니다.

pytest를 이용한 테스트 결과, 정상 작동함을 확인하였습니다.